### PR TITLE
Feature/error handling in cli

### DIFF
--- a/yappa/cli.py
+++ b/yappa/cli.py
@@ -78,7 +78,14 @@ def setup(config_file, token):
     except _InactiveRpcError as e:
         click.echo(f"{e.details()}")
         return
-    save_key(yc.create_service_account_key(account.id))
+    try:
+        save_key(yc.create_service_account_key(account.id))
+    except _InactiveRpcError as e:
+        click.echo(f"{e.details()}")
+        return
+    except Exception as e:
+        click.echo(f"{e}")
+        return
     click.echo("Saved service account credentials at " + click.style(
         DEFAULT_ACCESS_KEY_FILE, bold=True))
 

--- a/yappa/cli.py
+++ b/yappa/cli.py
@@ -91,7 +91,7 @@ def setup(config_file, token):
     except RpcError as e:
         click.echo(f"{e.details()}")
         return
-    except Exception as e:
+    except OSError as e:
         click.echo(f"{e}")
         return
 
@@ -131,7 +131,7 @@ def deploy(upload_strategy, config_file):
     except RpcError as e:
         click.echo(f"{e.details()}")
         return
-    except Exception as e:
+    except OSError as e:
         click.echo(f"{e}")
         return
 
@@ -162,7 +162,7 @@ def undeploy(config_file):
     except RpcError as e:
         click.echo(f"{e.details()}")
         return
-    except Exception as e:
+    except OSError as e:
         click.echo(f"{e}")
         return
 
@@ -186,7 +186,7 @@ def manage(config_file, command, args):
     except RpcError as e:
         click.echo(f"{e.details()}")
         return
-    except Exception as e:
+    except OSError as e:
         click.echo(f"{e}")
         return
 


### PR DESCRIPTION
# Add error handling to cli function

Every cli function have many calls of yandexcloud and file handle. I added handler of yandexcloud and file errors.
Yandex cloud could return `_InactiveRpcError `, which means 4xx from the cloud. `_InactiveRpcError ` is child of `RpcError`.
File system could return `OSError`