### PR TITLE
Fix exception for numerical env variables

### DIFF
--- a/examples/raw_function_postgres/function.py
+++ b/examples/raw_function_postgres/function.py
@@ -12,5 +12,4 @@ def handler(event, context):
         sslmode="require")
     cursor = connection.cursor()
     cursor.execute("SELECT 42;")
-    record = cursor.fetchall()
-    return record
+    return cursor.fetchall()

--- a/tests/packaging/s3.py
+++ b/tests/packaging/s3.py
@@ -50,7 +50,7 @@ def test_files_copy(apps_dir, config, expected_paths, config_filename):
 
 @pytest.fixture
 def bucket_name():
-    return "testbucket-" + str(uuid4())[:8]
+    return f"testbucket-{str(uuid4())[:8]}"
 
 
 def get_bucket_names(aws_access_key_id, aws_secret_access_key):

--- a/yappa/cli.py
+++ b/yappa/cli.py
@@ -97,9 +97,7 @@ def setup(config_file, token):
     config["folder_id"] = folders[folder_name]
     config["service_account_names"]["creator"] = account.name
     save_yaml(config, config_file)
-    click.echo(
-        "Saved Yappa config file at " + click.style(config_file, bold=True)
-    )
+    click.echo(f"Saved Yappa config file at {click.style(config_file, bold=True)}")
 
 
 @cli.command(short_help="generate config files, create function & api-gateway")
@@ -128,9 +126,7 @@ def deploy(upload_strategy, config_file):
     config, is_updated = get_missing_details(config)
     if is_updated:
         save_yaml(config, config_file)
-        click.echo(
-            "saved Yappa config file at " + click.style(config_file, bold=True)
-        )
+        click.echo(f"saved Yappa config file at {click.style(config_file, bold=True)}")
     yc = YC.setup(config=config)
     function = ensure_function(
         yc, config["project_slug"], config["description"], True

--- a/yappa/cli_helpers.py
+++ b/yappa/cli_helpers.py
@@ -91,9 +91,7 @@ def create_gateway(yc, config, function_id):
 
 def update_gateway(yc, config):
     gateway = yc.get_gateway(config["project_slug"])
-    click.echo(
-        "Updating api-gateway " + click.style(f"{gateway.name}", bold=True)
-    )
+    click.echo(f'Updating api-gateway {click.style(f"{gateway.name}", bold=True)}')
     yc.update_gateway(
         gateway.name, config["description"], load_yaml(config["gw_config"])
     )

--- a/yappa/handlers/common.py
+++ b/yappa/handlers/common.py
@@ -62,10 +62,7 @@ ENCODED_CONTENT_TYPES = (
 
 def is_binary(response):
     content_type = response.headers["content-type"]
-    for re_ in ENCODED_CONTENT_TYPES:
-        if re_.match(content_type):
-            return True
-    return False
+    return any(re_.match(content_type) for re_ in ENCODED_CONTENT_TYPES)
 
 
 def patch_response(response):

--- a/yappa/handlers/wsgi.py
+++ b/yappa/handlers/wsgi.py
@@ -22,8 +22,7 @@ def load_app(import_path, django_settings_module=None):
     os.environ["DJANGO_SETTINGS_MODULE"] = django_settings_module or ""
     *submodules, app_name = import_path.split(".")
     module = import_module(".".join(submodules))
-    application = getattr(module, app_name)
-    return application
+    return getattr(module, app_name)
 
 
 def call_app(application, event):
@@ -45,8 +44,7 @@ def call_app(application, event):
             params=event["queryStringParameters"],
             content=event["body"],
         )
-        response = client.send(request)
-        return response
+        return client.send(request)
 
 
 try:

--- a/yappa/packaging/common.py
+++ b/yappa/packaging/common.py
@@ -25,3 +25,7 @@ def validate_requirements_file(requirements_filename):
                 "Please update requirements running "
                 "'$pip freeze > requirements.txt'"
             )
+
+
+def env_vars_to_string(env_vars):
+    return {k: str(v) for k, v in env_vars.items()}

--- a/yappa/packaging/direct.py
+++ b/yappa/packaging/direct.py
@@ -35,9 +35,7 @@ def clear_requirements(requirements_file):
         return
     buffer = []
     with open(requirements_file, "r", encoding=ENCODING) as f:
-        for line in f.readlines():
-            if "yappa" not in line:
-                buffer.append(line)
+        buffer.extend(line for line in f if "yappa" not in line)
     with open(requirements_file, "w+", encoding=ENCODING) as f:
         f.write("".join(buffer))
 
@@ -164,10 +162,9 @@ def create_function_version(yc, config, config_filename):
     finally:
         os.remove(archive_path)
         rmtree(package_dir)
-    access_changed = yc.set_function_access(
+    if access_changed := yc.set_function_access(
         function_name=config["project_slug"], is_public=config["is_public"]
-    )
-    if access_changed:
+    ):
         click.echo(
             f"Changed function access. Now it is "
             f" {'not' if config['is_public'] else 'open to'} public"

--- a/yappa/packaging/direct.py
+++ b/yappa/packaging/direct.py
@@ -9,7 +9,7 @@ from click import ClickException
 
 from yappa.handlers.common import DEFAULT_CONFIG_FILENAME
 from yappa.packaging.common import validate_requirements_file, ENCODING, \
-    IS_WINDOWS
+    IS_WINDOWS, env_vars_to_string
 from yappa.settings import (
     DEFAULT_IGNORED_FILES,
     DEFAULT_PACKAGE_DIR,
@@ -102,6 +102,7 @@ def to_readable_size(size):
             return f"{size / s:.3f}{suffix}"
 
 
+
 def create_function_version(yc, config, config_filename):
     click.echo("Preparing package...")
     package_dir = prepare_package(
@@ -139,7 +140,7 @@ def create_function_version(yc, config, config_filename):
                 service_account_id=config["service_account_id"],
                 timeout=config["timeout"],
                 named_service_accounts=config["named_service_accounts"],
-                environment=config["environment"],
+                environment=env_vars_to_string(config["environment"]),
             )
             click.echo("Created function version")
             if config["django_settings_module"]:
@@ -158,7 +159,7 @@ def create_function_version(yc, config, config_filename):
                     service_account_id=config["service_account_id"],
                     timeout=60 * 10,
                     named_service_accounts=config["named_service_accounts"],
-                    environment=config["environment"],
+                    environment=env_vars_to_string(config["environment"]),
                 )
     finally:
         os.remove(archive_path)

--- a/yappa/packaging/s3.py
+++ b/yappa/packaging/s3.py
@@ -10,7 +10,8 @@ import boto3
 import click
 
 from yappa.handlers.common import DEFAULT_CONFIG_FILENAME
-from yappa.packaging.common import validate_requirements_file
+from yappa.packaging.common import validate_requirements_file, \
+    env_vars_to_string
 from yappa.settings import (
     DEFAULT_IGNORED_FILES,
     DEFAULT_PACKAGE_DIR,
@@ -152,7 +153,7 @@ def create_function_version(yc, config, config_filename):
         service_account_id=config["service_account_id"],
         timeout=config["timeout"],
         named_service_accounts=config["named_service_accounts"],
-        environment=config["environment"],
+        environment=env_vars_to_string(config["environment"]),
     )
     click.echo("Created function version")
     access_changed = yc.set_function_access(
@@ -176,5 +177,5 @@ def create_function_version(yc, config, config_filename):
             service_account_id=config["service_account_id"],
             timeout=300,
             named_service_accounts=config["named_service_accounts"],
-            environment=config["environment"],
+            environment=env_vars_to_string(config["environment"]),
         )

--- a/yappa/packaging/s3.py
+++ b/yappa/packaging/s3.py
@@ -156,10 +156,9 @@ def create_function_version(yc, config, config_filename):
         environment=env_vars_to_string(config["environment"]),
     )
     click.echo("Created function version")
-    access_changed = yc.set_function_access(
+    if access_changed := yc.set_function_access(
         function_name=config["project_slug"], is_public=config["is_public"]
-    )
-    if access_changed:
+    ):
         click.echo(
             f"Changed function access. Now it is "
             f" {'not' if config['is_public'] else 'open to'} public"

--- a/yappa/utils.py
+++ b/yappa/utils.py
@@ -14,7 +14,7 @@ SIZE_SUFFIXES = {
 def convert_size_to_bytes(size_str):
     for suffix, value in SIZE_SUFFIXES.items():
         if size_str.lower().endswith(suffix):
-            size = int(size_str[0 : -len(suffix)]) * value
+            size = int(size_str[:-len(suffix)]) * value
             if not MIN_MEMORY <= size <= MAX_MEMORY:
                 raise ValueError(
                     "Sorry. Due to YandexCloud limits, function "

--- a/yappa/yc/__init__.py
+++ b/yappa/yc/__init__.py
@@ -54,10 +54,10 @@ class YC(YcAccessMixin, YcFunctionsMixin, YcGatewayMixin):
             )
         if skip_folder:
             return cls(**credentials)
-        folder_id = config.get("folder_id") or os.environ.get("YC_FOLDER")
-        if not folder_id:
+        if folder_id := config.get("folder_id") or os.environ.get("YC_FOLDER"):
+            return cls(folder_id=folder_id, **credentials)
+        else:
             raise ClickException(
                 "Sorry. Couldn't load folder_id from config "
                 "file or YC_FOLDER environment variable"
             )
-        return cls(folder_id=folder_id, **credentials)

--- a/yappa/yc/functions.py
+++ b/yappa/yc/functions.py
@@ -205,10 +205,9 @@ class YcFunctionsMixin:
         return operation_result.response
 
     def get_latest_version(self, function_id) -> Version:
-        version = self.sdk.client(FunctionServiceStub).GetVersionByTag(
+        return self.sdk.client(FunctionServiceStub).GetVersionByTag(
             GetFunctionVersionByTagRequest(
                 function_id=function_id,
                 tag="$latest",
             )
         )
-        return version

--- a/yappa/yc/gateway.py
+++ b/yappa/yc/gateway.py
@@ -82,6 +82,5 @@ class YcGatewayMixin:
         self, gateway_name, description, openapi_spec
     ) -> ApiGateway:
         logger.warning("Update gateway is not yet implemented")
-        gateway = self.get_gateway(gateway_name)
         # TODO implement update
-        return gateway
+        return self.get_gateway(gateway_name)


### PR DESCRIPTION
Fixed TypeError exception when using non-string values in environment variables.

Example of an exception:
```TypeError: -1001586367279 has type int, but expected one of: bytes, unicode```