### PR TITLE
Update requirements.txt djangorestframework version

### DIFF
--- a/examples/django/0_drf_base_no_db/requirements.txt
+++ b/examples/django/0_drf_base_no_db/requirements.txt
@@ -9,7 +9,7 @@ charset-normalizer==2.0.3
 click==8.0.1
 cryptography==3.4.7
 Django
-djangorestframework==3.12.4
+djangorestframework
 furl==2.1.2
 googleapis-common-protos==1.53.0
 grpcio==1.38.1


### PR DESCRIPTION
When specifying the version of djangorestframework, an error "cannot import name 'parse_header' from 'django.http.multipartparser' (/function/code/django/http/multipartparser.py)" appears due to version mismatch between Django and djangorestframework