### PR TITLE
TypeError fix

### DIFF
--- a/yappa/yc/function_call.py
+++ b/yappa/yc/function_call.py
@@ -14,7 +14,7 @@ def call_manage_function(yc, function_id, command, args):
 
 def call_function(function_id, token, method, body):
     url = (furl(YANDEX_FUNCTIONS_URL) / function_id).url
-    with httpx.Client(headers=dict(Authorization=f"Bearer {token}")) as client:
+    with httpx.Client(headers=dict(Authorization=f"Bearer {token}"), timeout=600) as client:
         request = client.build_request(method, url, json=body)
-        response = client.send(request, timeout=600)
+        response = client.send(request)
     return response


### PR DESCRIPTION
Fix bug: "TypeError: Client.send() got an unexpected keyword argument 'timeout'" when running manage functions.